### PR TITLE
Adds -i flag to ignore submodules during pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Non-Git packages are added individually, vendored into the parent repo. You may
 want to add `.hg` and `.bzr` to your `.gitignore`.
 
 Any extra submodules under the `$GOPATH` are then removed. This is to prune
-no-longer-needed dependencies.
+no-longer-needed dependencies. Specify the '-i' flag for each submodule you 
+would like to avoid pruning.
 
 ```sh
 $ gosub sync github.com/my/app github.com/my/lib ...

--- a/main.go
+++ b/main.go
@@ -42,6 +42,11 @@ func main() {
 					Name:  "gopath, g",
 					Value: ".",
 				},
+				cli.StringSliceFlag{
+					Name:  "ignore, i",
+					Value: &cli.StringSlice{},
+					Usage: "Submodule to ignore",
+				},
 			},
 			Action: sync,
 		},

--- a/sync.go
+++ b/sync.go
@@ -15,6 +15,7 @@ import (
 func sync(c *cli.Context) {
 	repo := c.String("repo")
 	gopath := c.String("gopath")
+	ignoredSubmodules := c.StringSlice("ignore")
 
 	absRepo, err := filepath.Abs(repo)
 	if err != nil {
@@ -51,6 +52,13 @@ func sync(c *cli.Context) {
 	submodulesToRemove := map[string]bool{}
 	for _, submodule := range existingSubmodules {
 		submodulesToRemove[submodule] = true
+	}
+
+	for _, submodule := range ignoredSubmodules {
+		_, exists := submodulesToRemove[submodule]
+		if exists {
+			delete(submodulesToRemove, submodule)
+		}
 	}
 
 	for pkgRoot, pkgRepo := range pkgRoots {


### PR DESCRIPTION
-i takes a submodule path for each submodule you don't want gosub to mess with.
