### PR TITLE
Use existing submodule URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,10 @@ func main() {
 					Value: &cli.StringSlice{},
 					Usage: "Submodule to ignore",
 				},
+				cli.BoolTFlag{
+					Name: "force-https",
+					Usage: "Rewrite ssh repositories as https. (default \"true\")",
+				},
 			},
 			Action: sync,
 		},

--- a/sync.go
+++ b/sync.go
@@ -108,17 +108,17 @@ func sync(c *cli.Context) error {
 			return fmt.Errorf("error configuring submodule: %s", err)
 		}
 
-		gitConfig = exec.Command("git", "config", "--file", gitmodules, "submodule."+relRoot+".url")
-		gitConfig.Stderr = os.Stderr
+		url := httpsOrigin(pkgRepo.Origin)
 
-		out, err := gitConfig.Output()
+		if !c.Bool("force-https") {
+			gitConfig = exec.Command("git", "config", "--file", gitmodules, "submodule." + relRoot + ".url")
+			gitConfig.Stderr = os.Stderr
 
-		var url string
+			out, err := gitConfig.Output()
 
-		if err != nil {
-			url = httpsOrigin(pkgRepo.Origin)
-		} else {
-			url = strings.TrimRight(string(out),"\n")
+			if err == nil {
+				url = strings.TrimRight(string(out), "\n")
+			}
 		}
 
 		gitConfig = exec.Command("git", "config", "--file", gitmodules, "submodule."+relRoot+".url", url)

--- a/sync.go
+++ b/sync.go
@@ -108,7 +108,20 @@ func sync(c *cli.Context) error {
 			return fmt.Errorf("error configuring submodule: %s", err)
 		}
 
-		gitConfig = exec.Command("git", "config", "--file", gitmodules, "submodule."+relRoot+".url", httpsOrigin(pkgRepo.Origin))
+		gitConfig = exec.Command("git", "config", "--file", gitmodules, "submodule."+relRoot+".url")
+		gitConfig.Stderr = os.Stderr
+
+		out, err := gitConfig.Output()
+
+		var url string
+
+		if err != nil {
+			url = httpsOrigin(pkgRepo.Origin)
+		} else {
+			url = strings.TrimRight(string(out),"\n")
+		}
+
+		gitConfig = exec.Command("git", "config", "--file", gitmodules, "submodule."+relRoot+".url", url)
 		gitConfig.Stderr = os.Stderr
 
 		err = gitConfig.Run()


### PR DESCRIPTION
- During 'sync', if a submodule is found, then use it's url without mutation.
  This let's existing ssh style git urls continue to work.

Fixes #1

Signed-off-by: Rasheed Abdul-Aziz rabdulaziz@pivotal.io
