### PR TITLE
Fix exit code

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/codegangsta/cli"
@@ -72,5 +73,8 @@ func main() {
 		},
 	}
 
-	app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 					Usage: "Submodule to ignore",
 				},
 				cli.BoolTFlag{
-					Name: "force-https",
+					Name:  "force-https",
 					Usage: "Rewrite ssh repositories as https. (default \"true\")",
 				},
 			},

--- a/sync.go
+++ b/sync.go
@@ -111,7 +111,7 @@ func sync(c *cli.Context) error {
 		url := httpsOrigin(pkgRepo.Origin)
 
 		if !c.Bool("force-https") {
-			gitConfig = exec.Command("git", "config", "--file", gitmodules, "submodule." + relRoot + ".url")
+			gitConfig = exec.Command("git", "config", "--file", gitmodules, "submodule."+relRoot+".url")
 			gitConfig.Stderr = os.Stderr
 
 			out, err := gitConfig.Output()


### PR DESCRIPTION
This change makes gosub blow up if something went wrong instead of silently exiting with status code `0`