### PR TITLE
Add HOME to command env when executing `go list`

### DIFF
--- a/package.go
+++ b/package.go
@@ -45,7 +45,7 @@ func listPackages(pkgs map[string]Package, goos string, ps ...string) error {
 			"go",
 			append([]string{"list", "-e", "-json"}, packages...)...,
 		)
-		listPackages.Env = []string{"GOOS=" + goos, "GOPATH=" + os.Getenv("GOPATH")}
+		listPackages.Env = []string{"GOOS=" + goos, "GOPATH=" + os.Getenv("GOPATH"), "HOME=" + os.Getenv("HOME")}
 
 		listPackages.Stderr = os.Stderr
 


### PR DESCRIPTION
This fixes a problem with go-1.12 where it needs $GOCACHE to be
explicitly provided, or inferred from $HOME.

e.g. We see the following error running gosub with go-1.12:
```
build cache is required, but could not be located: GOCACHE is not defined and $HOME is not defined
```

Signed-off-by: Kieron Browne <kbrowne@pivotal.io>
Co-authored-by: Kieron Browne <kbrowne@pivotal.io>