### PR TITLE
Fix `codegangsta` references

### DIFF
--- a/fix.go
+++ b/fix.go
@@ -10,7 +10,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 func fix(c *cli.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/vito/gosub
 
 go 1.12
 
-require github.com/codegangsta/cli v1.20.0
+require github.com/urfave/cli v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/codegangsta/cli v1.20.0 h1:iX1FXEgwzd5+XN6wk5cVHOGQj6Q3Dcp20lUeS4lHNTw=
-github.com/codegangsta/cli v1.20.0/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=
+github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
+github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/list.go
+++ b/list.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 func list(c *cli.Context) error {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 func main() {

--- a/sync.go
+++ b/sync.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 func sync(c *cli.Context) error {


### PR DESCRIPTION
`codegangsta/cli` reference apparently has been deprecated and we should be using `urfave/cli` instead now.

Couldn't find any tests to run, but ran the compiled binary and seems like it's still working correctly.

Thanks!