### PR TITLE
Add option for go build flags

### DIFF
--- a/package.go
+++ b/package.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"sort"
+	"strings"
 )
 
 const packageBatchSize = 100
@@ -41,9 +42,14 @@ func listPackages(pkgs map[string]Package, goos string, ps ...string) error {
 			remainingPackages = remainingPackages[packageBatchSize:]
 		}
 
+		flags := []string{"list", "-e", "-json"}
+		if v, exists := os.LookupEnv("BUILD_FLAGS"); exists {
+			flags = append(flags, strings.Split(v, " ")...)
+		}
+
 		listPackages := exec.Command(
 			"go",
-			append([]string{"list", "-e", "-json"}, packages...)...,
+			append(flags, packages...)...,
 		)
 		listPackages.Env = []string{"GOOS=" + goos, "GOPATH=" + os.Getenv("GOPATH"), "HOME=" + os.Getenv("HOME")}
 


### PR DESCRIPTION
Currently we can't pull in correct depedencies for binaries that require build_flags. [runc's seccomp](https://github.com/opencontainers/runc/blob/a2f27f05e86326f27134e79370f431c2c098348d/libcontainer/seccomp/seccomp_linux.go#L2) is an example of this. With this change, we can set `BUILD_FLAGS="--tags cgo,seccomp"` and it will correctly pull in imports.