### PR TITLE
Fix for go1.20.x

### DIFF
--- a/package.go
+++ b/package.go
@@ -51,7 +51,7 @@ func listPackages(pkgs map[string]Package, goos string, ps ...string) error {
 			"go",
 			append(flags, packages...)...,
 		)
-		listPackages.Env = []string{"GOOS=" + goos, "GOPATH=" + os.Getenv("GOPATH"), "HOME=" + os.Getenv("HOME")}
+		listPackages.Env = []string{"GOOS=" + goos, "GOPATH=" + os.Getenv("GOPATH"), "HOME=" + os.Getenv("HOME"), "PATH=" + os.Getenv("PATH")}
 
 		listPackages.Stderr = os.Stderr
 


### PR DESCRIPTION
As of go1.20.x `CGO_ENABLED` will be turned off if gcc is not found on PATH. This change will ensure PATH is included when running go commands.

Context: https://go.dev/doc/go1.20#cgo